### PR TITLE
Safe area for the map view

### DIFF
--- a/Example/cards/ExampleMapManager.swift
+++ b/Example/cards/ExampleMapManager.swift
@@ -58,10 +58,10 @@ class ExampleMapManager: TGMapManager, NSCoding {
     aCoder.encode(annotations.map(CodingAnnotation.init), forKey: "annotations")
   }
   
-  override func takeCharge(of mapView: MKMapView, edgePadding: UIEdgeInsets, animated: Bool) {
+  override func takeCharge(of mapView: MKMapView, animated: Bool) {
     mapView.delegate = self
     
-    super.takeCharge(of: mapView, edgePadding: edgePadding, animated: animated)
+    super.takeCharge(of: mapView, animated: animated)
   }
   
   func mapView(_ mapView: MKMapView, didChange mode: MKUserTrackingMode, animated: Bool) {

--- a/Example/cards/ExampleRootCard.swift
+++ b/Example/cards/ExampleRootCard.swift
@@ -22,7 +22,7 @@ class ExampleRootCard : TGTableCard {
     #else
     title = .default("Card Demo")
     #endif
-    super.init(title: title, dataSource: source, delegate: source, mapManager: TGMapManager.nuremberg)
+    super.init(title: title, dataSource: source, delegate: source, mapManager: TGMapManager.nuremberg, initialPosition: .collapsed)
     
     source.onSelect = { item in
       self.controller?.push(item.card)

--- a/Sources/TGCardViewController/TGCardViewController.swift
+++ b/Sources/TGCardViewController/TGCardViewController.swift
@@ -663,12 +663,6 @@ open class TGCardViewController: UIViewController {
   ///         map area to work with).
   fileprivate func mapEdgePadding(for position: TGCardPosition) -> UIEdgeInsets {
     assert(mapView.frame.isEmpty == false, "Don't call this before we have a map view frame.")
-    
-    if true {
-      // This is not necessary anymore as we're setting the additional safe area
-      return .zero
-    }
-    
     let top: CGFloat
     let bottom: CGFloat
     let left: CGFloat
@@ -696,7 +690,6 @@ open class TGCardViewController: UIViewController {
       let height = max(mapView.frame.width, mapView.frame.height)
       bottom = height - cardY
     }
-    
     
     return UIEdgeInsets(top: top, left: left, bottom: bottom, right: 0)
   }

--- a/Sources/TGCardViewController/TGCardViewController.xib
+++ b/Sources/TGCardViewController/TGCardViewController.xib
@@ -51,7 +51,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                     <subviews>
                         <view clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="zI8-lz-Md7" userLabel="Map View Wrapper">
-                            <rect key="frame" x="0.0" y="60" width="375" height="752"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="Bxf-J1-ygI" userLabel="Top Info Wrapper">
                             <rect key="frame" x="16" y="52" width="343" height="44"/>
@@ -152,7 +152,7 @@
                             </constraints>
                         </view>
                         <view userInteractionEnabled="NO" alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1uG-yl-0le" userLabel="Map Shadow">
-                            <rect key="frame" x="0.0" y="60" width="375" height="752"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             <accessibility key="accessibilityConfiguration">
                                 <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -214,10 +214,10 @@
                             </userDefinedRuntimeAttributes>
                         </visualEffectView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bui-Tf-j0O" userLabel="Card Wrapper Shadow">
-                            <rect key="frame" x="0.0" y="560" width="375" height="702"/>
+                            <rect key="frame" x="0.0" y="560" width="375" height="762"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aqL-1W-7nJ" userLabel="Card Wrapper Content">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="702"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="762"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 </view>
                             </subviews>
@@ -250,7 +250,6 @@
                         <constraint firstItem="zI8-lz-Md7" firstAttribute="top" secondItem="XA2-1g-kYz" secondAttribute="top" id="0es-h4-clN"/>
                         <constraint firstItem="DJJ-p5-rXz" firstAttribute="top" secondItem="p4A-z3-3Ce" secondAttribute="top" constant="8" id="0oW-ac-gCq"/>
                         <constraint firstItem="ewk-8T-6Fw" firstAttribute="trailing" secondItem="Bui-Tf-j0O" secondAttribute="trailing" id="0wl-hr-BEj"/>
-                        <constraint firstItem="zI8-lz-Md7" firstAttribute="top" secondItem="ewk-8T-6Fw" secondAttribute="bottom" id="1Mc-Uh-pXD"/>
                         <constraint firstItem="1uG-yl-0le" firstAttribute="centerX" secondItem="zI8-lz-Md7" secondAttribute="centerX" id="4HE-3s-wMK"/>
                         <constraint firstAttribute="trailing" secondItem="u6M-z2-2xb" secondAttribute="trailing" constant="22" id="4dC-NG-76m"/>
                         <constraint firstItem="Bui-Tf-j0O" firstAttribute="width" secondItem="XA2-1g-kYz" secondAttribute="width" multiplier="0.38" id="52A-gC-vvw"/>
@@ -292,7 +291,6 @@
                     <variation key="default">
                         <mask key="constraints">
                             <exclude reference="iRG-l2-Ubl"/>
-                            <exclude reference="0es-h4-clN"/>
                             <exclude reference="QcC-bz-xjm"/>
                             <exclude reference="Xw1-VR-Evc"/>
                             <exclude reference="52A-gC-vvw"/>
@@ -311,8 +309,6 @@
                         </mask>
                         <mask key="constraints">
                             <include reference="iRG-l2-Ubl"/>
-                            <include reference="0es-h4-clN"/>
-                            <exclude reference="1Mc-Uh-pXD"/>
                             <include reference="QcC-bz-xjm"/>
                             <exclude reference="aLo-hb-3fH"/>
                             <exclude reference="7ls-iv-MHj"/>
@@ -325,8 +321,6 @@
                         </mask>
                         <mask key="constraints">
                             <include reference="Vi9-1z-ei1"/>
-                            <include reference="0es-h4-clN"/>
-                            <exclude reference="1Mc-Uh-pXD"/>
                             <include reference="52A-gC-vvw"/>
                             <exclude reference="DGx-yq-huX"/>
                         </mask>

--- a/Sources/TGCardViewController/TGCardViewController.xib
+++ b/Sources/TGCardViewController/TGCardViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="ipad12_9rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -44,29 +44,29 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" restorationIdentifier="CardViewController" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XA2-1g-kYz" userLabel="Content View">
-                    <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                     <subviews>
                         <view clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="zI8-lz-Md7" userLabel="Map View Wrapper">
-                            <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
+                            <rect key="frame" x="0.0" y="44" width="375" height="768"/>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="Bxf-J1-ygI" userLabel="Top Info Wrapper">
-                            <rect key="frame" x="376" y="8" width="272" height="44"/>
+                            <rect key="frame" x="16" y="52" width="343" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" priority="750" constant="44" placeholder="YES" id="SYM-Qy-rtL"/>
                             </constraints>
                         </view>
                         <visualEffectView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="749" placeholderIntrinsicWidth="45" placeholderIntrinsicHeight="91" translatesAutoresizingMaskIntoConstraints="NO" id="DJJ-p5-rXz" userLabel="Top Floating View Wrapper">
-                            <rect key="frame" x="664" y="8" width="352" height="91"/>
+                            <rect key="frame" x="367" y="52" width="0.0" height="91"/>
                             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="3Nr-Q0-9p1">
-                                <rect key="frame" x="0.0" y="0.0" width="352" height="91"/>
+                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="91"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="KR7-zo-rfe" userLabel="Top floating view">
-                                        <rect key="frame" x="0.0" y="0.0" width="352" height="91"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="91"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="detailDisclosure" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vUA-9F-ExZ">
                                                 <rect key="frame" x="0.0" y="0.0" width="45" height="45"/>
@@ -108,19 +108,19 @@
                             </userDefinedRuntimeAttributes>
                         </visualEffectView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zlR-ey-yL8" userLabel="Sidebar Background">
-                            <rect key="frame" x="0.0" y="0.0" width="360" height="1346"/>
+                            <rect key="frame" x="0.0" y="44" width="375" height="734"/>
                             <subviews>
                                 <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IEW-xx-P4c">
-                                    <rect key="frame" x="0.0" y="0.0" width="360" height="1346"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="734"/>
                                     <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="KLf-du-5ZR">
-                                        <rect key="frame" x="0.0" y="0.0" width="360" height="1346"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="734"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
                                             <visualEffectView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EWh-dP-38F">
-                                                <rect key="frame" x="0.0" y="0.0" width="120" height="1218"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="135" height="606"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="PaT-N6-scp">
-                                                    <rect key="frame" x="0.0" y="0.0" width="120" height="1218"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="135" height="606"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 </view>
                                                 <vibrancyEffect>
@@ -133,7 +133,7 @@
                                     <blurEffect style="regular"/>
                                 </visualEffectView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2dL-e1-o2y">
-                                    <rect key="frame" x="360" y="0.0" width="1" height="1346"/>
+                                    <rect key="frame" x="375" y="0.0" width="1" height="734"/>
                                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="1" id="QnL-37-2Pi"/>
@@ -152,17 +152,21 @@
                             </constraints>
                         </view>
                         <view userInteractionEnabled="NO" alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1uG-yl-0le" userLabel="Map Shadow">
-                            <rect key="frame" x="0.0" y="44" width="414" height="852"/>
+                            <rect key="frame" x="0.0" y="44" width="375" height="768"/>
                             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                            <accessibility key="accessibilityConfiguration">
+                                <accessibilityTraits key="traits" notEnabled="YES"/>
+                                <bool key="isElement" value="YES"/>
+                            </accessibility>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ewk-8T-6Fw" userLabel="Header View">
-                            <rect key="frame" x="0.0" y="0.0" width="360" height="60"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="60"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="60" id="dMP-Sd-KN9"/>
                             </constraints>
                         </view>
                         <visualEffectView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="91" placeholderIntrinsicHeight="45" translatesAutoresizingMaskIntoConstraints="NO" id="u6M-z2-2xb" userLabel="Bottom Floating View Wrapper">
-                            <rect key="frame" x="925" y="1293" width="91" height="45"/>
+                            <rect key="frame" x="276" y="507" width="91" height="45"/>
                             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="qM8-dd-KXi">
                                 <rect key="frame" x="0.0" y="0.0" width="91" height="45"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -210,10 +214,10 @@
                             </userDefinedRuntimeAttributes>
                         </visualEffectView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bui-Tf-j0O" userLabel="Card Wrapper Shadow">
-                            <rect key="frame" x="0.0" y="560" width="360" height="1316"/>
+                            <rect key="frame" x="0.0" y="560" width="375" height="718"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aqL-1W-7nJ" userLabel="Card Wrapper Content">
-                                    <rect key="frame" x="0.0" y="0.0" width="360" height="1316"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="718"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 </view>
                             </subviews>
@@ -251,7 +255,7 @@
                         <constraint firstAttribute="trailing" secondItem="u6M-z2-2xb" secondAttribute="trailing" constant="22" id="4dC-NG-76m"/>
                         <constraint firstItem="Bui-Tf-j0O" firstAttribute="width" secondItem="XA2-1g-kYz" secondAttribute="width" multiplier="0.38" id="52A-gC-vvw"/>
                         <constraint firstItem="DJJ-p5-rXz" firstAttribute="top" secondItem="Bxf-J1-ygI" secondAttribute="top" id="6kN-Lc-OQo"/>
-                        <constraint firstItem="Bui-Tf-j0O" firstAttribute="top" secondItem="u6M-z2-2xb" secondAttribute="bottom" constant="8" id="7ls-iv-MHj"/>
+                        <constraint firstItem="Bui-Tf-j0O" firstAttribute="top" secondItem="u6M-z2-2xb" secondAttribute="bottom" priority="250" constant="8" id="7ls-iv-MHj"/>
                         <constraint firstItem="p4A-z3-3Ce" firstAttribute="bottom" secondItem="zlR-ey-yL8" secondAttribute="bottom" id="99e-sv-Sle"/>
                         <constraint firstItem="Bui-Tf-j0O" firstAttribute="leading" secondItem="p4A-z3-3Ce" secondAttribute="leading" priority="999" id="D5D-bp-P3t">
                             <variation key="widthClass=regular" constant="8"/>
@@ -281,14 +285,15 @@
                         <constraint firstItem="zI8-lz-Md7" firstAttribute="leading" secondItem="XA2-1g-kYz" secondAttribute="leading" id="qWk-nn-wsJ"/>
                         <constraint firstAttribute="bottom" secondItem="zI8-lz-Md7" secondAttribute="bottom" id="sRh-ZW-PW0"/>
                         <constraint firstItem="Bui-Tf-j0O" firstAttribute="leading" secondItem="p4A-z3-3Ce" secondAttribute="leading" id="tnn-M0-K20"/>
+                        <constraint firstItem="p4A-z3-3Ce" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="u6M-z2-2xb" secondAttribute="bottom" constant="32" id="xKO-88-hba"/>
                         <constraint firstItem="ewk-8T-6Fw" firstAttribute="leading" secondItem="Bui-Tf-j0O" secondAttribute="leading" id="xxs-tH-iF9"/>
-                        <constraint firstItem="p4A-z3-3Ce" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Bui-Tf-j0O" secondAttribute="top" constant="100" id="zKc-st-3DD"/>
+                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Bui-Tf-j0O" secondAttribute="top" id="zKc-st-3DD"/>
                     </constraints>
                     <variation key="default">
                         <mask key="constraints">
                             <exclude reference="iRG-l2-Ubl"/>
-                            <exclude reference="QcC-bz-xjm"/>
                             <exclude reference="0es-h4-clN"/>
+                            <exclude reference="QcC-bz-xjm"/>
                             <exclude reference="Xw1-VR-Evc"/>
                             <exclude reference="52A-gC-vvw"/>
                             <exclude reference="4dC-NG-76m"/>
@@ -306,10 +311,10 @@
                         </mask>
                         <mask key="constraints">
                             <include reference="iRG-l2-Ubl"/>
-                            <include reference="QcC-bz-xjm"/>
-                            <exclude reference="aLo-hb-3fH"/>
                             <include reference="0es-h4-clN"/>
                             <exclude reference="1Mc-Uh-pXD"/>
+                            <include reference="QcC-bz-xjm"/>
+                            <exclude reference="aLo-hb-3fH"/>
                             <exclude reference="7ls-iv-MHj"/>
                             <exclude reference="DGx-yq-huX"/>
                         </mask>
@@ -328,9 +333,9 @@
                     </variation>
                 </view>
                 <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hZy-nx-c0N">
-                    <rect key="frame" x="0.0" y="0.0" width="1024" height="20"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="20"/>
                     <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="Dt1-tF-s3W">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="20"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="20"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     </view>
                     <constraints>

--- a/Sources/TGCardViewController/TGCardViewController.xib
+++ b/Sources/TGCardViewController/TGCardViewController.xib
@@ -51,7 +51,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                     <subviews>
                         <view clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="zI8-lz-Md7" userLabel="Map View Wrapper">
-                            <rect key="frame" x="0.0" y="44" width="375" height="768"/>
+                            <rect key="frame" x="0.0" y="60" width="375" height="752"/>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="Bxf-J1-ygI" userLabel="Top Info Wrapper">
                             <rect key="frame" x="16" y="52" width="343" height="44"/>
@@ -152,7 +152,7 @@
                             </constraints>
                         </view>
                         <view userInteractionEnabled="NO" alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1uG-yl-0le" userLabel="Map Shadow">
-                            <rect key="frame" x="0.0" y="44" width="375" height="768"/>
+                            <rect key="frame" x="0.0" y="60" width="375" height="752"/>
                             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             <accessibility key="accessibilityConfiguration">
                                 <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -214,10 +214,10 @@
                             </userDefinedRuntimeAttributes>
                         </visualEffectView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bui-Tf-j0O" userLabel="Card Wrapper Shadow">
-                            <rect key="frame" x="0.0" y="560" width="375" height="718"/>
+                            <rect key="frame" x="0.0" y="560" width="375" height="702"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aqL-1W-7nJ" userLabel="Card Wrapper Content">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="718"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="702"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 </view>
                             </subviews>
@@ -250,7 +250,7 @@
                         <constraint firstItem="zI8-lz-Md7" firstAttribute="top" secondItem="XA2-1g-kYz" secondAttribute="top" id="0es-h4-clN"/>
                         <constraint firstItem="DJJ-p5-rXz" firstAttribute="top" secondItem="p4A-z3-3Ce" secondAttribute="top" constant="8" id="0oW-ac-gCq"/>
                         <constraint firstItem="ewk-8T-6Fw" firstAttribute="trailing" secondItem="Bui-Tf-j0O" secondAttribute="trailing" id="0wl-hr-BEj"/>
-                        <constraint firstItem="zI8-lz-Md7" firstAttribute="top" secondItem="ewk-8T-6Fw" secondAttribute="bottom" constant="-16" id="1Mc-Uh-pXD"/>
+                        <constraint firstItem="zI8-lz-Md7" firstAttribute="top" secondItem="ewk-8T-6Fw" secondAttribute="bottom" id="1Mc-Uh-pXD"/>
                         <constraint firstItem="1uG-yl-0le" firstAttribute="centerX" secondItem="zI8-lz-Md7" secondAttribute="centerX" id="4HE-3s-wMK"/>
                         <constraint firstAttribute="trailing" secondItem="u6M-z2-2xb" secondAttribute="trailing" constant="22" id="4dC-NG-76m"/>
                         <constraint firstItem="Bui-Tf-j0O" firstAttribute="width" secondItem="XA2-1g-kYz" secondAttribute="width" multiplier="0.38" id="52A-gC-vvw"/>
@@ -287,7 +287,7 @@
                         <constraint firstItem="Bui-Tf-j0O" firstAttribute="leading" secondItem="p4A-z3-3Ce" secondAttribute="leading" id="tnn-M0-K20"/>
                         <constraint firstItem="p4A-z3-3Ce" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="u6M-z2-2xb" secondAttribute="bottom" constant="32" id="xKO-88-hba"/>
                         <constraint firstItem="ewk-8T-6Fw" firstAttribute="leading" secondItem="Bui-Tf-j0O" secondAttribute="leading" id="xxs-tH-iF9"/>
-                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Bui-Tf-j0O" secondAttribute="top" id="zKc-st-3DD"/>
+                        <constraint firstItem="p4A-z3-3Ce" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Bui-Tf-j0O" secondAttribute="top" id="zKc-st-3DD"/>
                     </constraints>
                     <variation key="default">
                         <mask key="constraints">

--- a/Sources/TGCardViewController/TGMapManager.swift
+++ b/Sources/TGCardViewController/TGMapManager.swift
@@ -76,15 +76,11 @@ open class TGMapManager: NSObject, TGCompatibleMapManager {
     return annotations
   }
   
-  open func reactToNewEdgePadding(_ edgePadding: UIEdgeInsets) {}
-  
   /// How zoomed in/out the map should be when displaying the
   /// content the first time. Defaults to `.city`
   public var preferredZoomLevel: Zoom = .city
   
-  public var edgePadding: UIEdgeInsets = .zero {
-    didSet { reactToNewEdgePadding(edgePadding)}
-  }
+  public var edgePadding: UIEdgeInsets = .zero
   
   /// Set to `false` to disable restoring the previous map rect when popping back to this
   public var restoreMapRect: Bool = true
@@ -99,27 +95,24 @@ open class TGMapManager: NSObject, TGCompatibleMapManager {
     return mapView != nil
   }
   
-  public override init() {
-  }
+  public override init() {}
   
   public func takeCharge(of mapView: UIView, edgePadding: UIEdgeInsets, animated: Bool) {
     guard let mapView = mapView as? MKMapView else { preconditionFailure() }
-    takeCharge(of: mapView, edgePadding: edgePadding, animated: animated)
+    self.edgePadding = edgePadding
+    takeCharge(of: mapView, animated: animated)
   }
   
   /// Takes charge of the map view, adding the map manager's content
   ///
   /// - Parameters:
   ///   - mapView: Map view to take charge of
-  ///   - edgePadding: Edge padding of the map view, e.g., if parts of the map view is
-  /// obscured by other views.
   ///   - animated: If adding content should be animated
-  open func takeCharge(of mapView: MKMapView, edgePadding: UIEdgeInsets, animated: Bool) {
+  open func takeCharge(of mapView: MKMapView, animated: Bool) {
     previousMapState = MapState(for: mapView)
     
     self.mapView = mapView
     mapView.delegate = self
-    self.edgePadding = edgePadding
     
     mapView.addAnnotations(annotations)
     
@@ -167,59 +160,41 @@ open class TGMapManager: NSObject, TGCompatibleMapManager {
   public func zoom(to annotations: [MKAnnotation], animated: Bool) {
     mapView?.showAnnotations(annotations,
                              minimumZoomLevel: preferredZoomLevel.rawValue,
-                             edgePadding: edgePadding,
                              animated: animated)
   }
 
   public func zoom(to mapRect: MKMapRect, animated: Bool) {
     mapView?.showMapRect(mapRect,
                          minimumZoomLevel: preferredZoomLevel.rawValue,
-                         edgePadding: edgePadding,
                          animated: animated)
   }
 
   public var centerCoordinate: CLLocationCoordinate2D? {
-    guard let mapView = mapView else { return nil }
-    
-    let visibleWidth = mapView.frame.width - edgePadding.left - edgePadding.right
-    let visibleHeight = mapView.frame.height - edgePadding.top - edgePadding.bottom
-    
-    let centerPoint = CGPoint(x: edgePadding.left + visibleWidth / 2, y: edgePadding.top + visibleHeight / 2)
-    return mapView.convert(centerPoint, toCoordinateFrom: mapView)
+    mapView?.centerCoordinate
   }
 
   public func setCenter(_ coordinate: CLLocationCoordinate2D, animated: Bool) {
-    mapView?.setCenter(coordinate, edgePadding: edgePadding, animated: animated)
+    mapView?.setCenter(coordinate, animated: animated)
   }
   
 }
 
-
-extension TGMapManager: MKMapViewDelegate {
-  
-}
-
+extension TGMapManager: MKMapViewDelegate {}
 
 extension MKMapView {
   
   func showAnnotations(_ annotations: [MKAnnotation],
                        minimumZoomLevel: Double,
-                       edgePadding: UIEdgeInsets = .zero,
                        animated: Bool) {
     
     guard !annotations.isEmpty else { return }
     
-    // Note: Using zero insets here as we'll respect the inspect already in the
-    //       call below when setting the visible map rect - otherwise we adjust
-    //       for it twice.
-    let mapRect = mapRectThatFits(annotations.boundingMapRect, edgePadding: .zero)
-    
-    showMapRect(mapRect, minimumZoomLevel: minimumZoomLevel, edgePadding: edgePadding, animated: animated)
+    let mapRect = mapRectThatFits(annotations.boundingMapRect)
+    showMapRect(mapRect, minimumZoomLevel: minimumZoomLevel, animated: animated)
   }
   
   func showMapRect(_ mapRect: MKMapRect,
                    minimumZoomLevel: Double,
-                   edgePadding: UIEdgeInsets = .zero,
                    animated: Bool) {
     
     guard !mapRect.isNull else { return }
@@ -231,43 +206,7 @@ extension MKMapView {
       mapRectToShow = self.mapRect(forZoomLevel: minimumZoomLevel, centeredOn: center)
     }
     
-    // If we're in extended mode, the edge padding is very large and zooming
-    // will zoom out a lot; so we cap it at half the height.
-    var edgePaddingToUse = edgePadding
-    if edgePaddingToUse.bottom > bounds.height / 2 {
-      edgePaddingToUse.bottom = bounds.height / 2
-    }
-    
-    setVisibleMapRect(mapRectToShow, edgePadding: edgePaddingToUse, animated: animated)
-  }
-  
-  func setCenter(_ coordinate: CLLocationCoordinate2D,
-                 edgePadding: UIEdgeInsets,
-                 animated: Bool) {
-    
-    // Coordinate at the currently visible center, considering edge padding
-    let visibleCenterPoint = CGPoint(
-      x: edgePadding.left + (frame.width - edgePadding.left - edgePadding.right) / 2,
-      y: edgePadding.top + (frame.height - edgePadding.top - edgePadding.bottom) / 2
-    )
-    let visibleCenter = convert(visibleCenterPoint, toCoordinateFrom: self)
-    
-    // Map view's center
-    let unadjustedCenter = centerCoordinate
-    
-    // New map view center, will be the desired coordinate, plus the offset
-    // Note: Won't work well if this is on a different part of the planet,
-    //       which is why we double check for validate coordinates below.
-    let newCenter = CLLocationCoordinate2D(
-      latitude: coordinate.latitude + (unadjustedCenter.latitude - visibleCenter.latitude) / 2,
-      longitude: coordinate.longitude + (unadjustedCenter.longitude - visibleCenter.longitude) / 2
-    )
-    
-    if CLLocationCoordinate2DIsValid(newCenter) {
-      setCenter(newCenter, animated: animated)
-    } else {
-      setCenter(coordinate, animated: animated)
-    }
+    setVisibleMapRect(mapRectToShow, animated: animated)
   }
   
 }
@@ -306,10 +245,10 @@ extension MKMapView {
     }
   }
   
-  func setZoomLevel(_ zoomLevel: Double, edgePadding: UIEdgeInsets = .zero, animated: Bool) {
+  func setZoomLevel(_ zoomLevel: Double, animated: Bool) {
     let center = MKMapPoint(centerCoordinate)
     let mapRect = self.mapRect(forZoomLevel: zoomLevel, centeredOn: center)
-    setVisibleMapRect(mapRect, edgePadding: edgePadding, animated: animated)
+    setVisibleMapRect(mapRect, animated: animated)
   }
   
   fileprivate func zoomLevel(of mapRect: MKMapRect) -> Double {

--- a/Sources/TGCardViewController/TGMapManager.swift
+++ b/Sources/TGCardViewController/TGMapManager.swift
@@ -76,11 +76,15 @@ open class TGMapManager: NSObject, TGCompatibleMapManager {
     return annotations
   }
   
+  open func edgePaddingDidUpdate(_ edgePadding: UIEdgeInsets) {}
+  
   /// How zoomed in/out the map should be when displaying the
   /// content the first time. Defaults to `.city`
   public var preferredZoomLevel: Zoom = .city
   
-  public var edgePadding: UIEdgeInsets = .zero
+  public var edgePadding: UIEdgeInsets = .zero {
+    didSet { edgePaddingDidUpdate(edgePadding)}
+  }
   
   /// Set to `false` to disable restoring the previous map rect when popping back to this
   public var restoreMapRect: Bool = true

--- a/Sources/TGCardViewController/TGMapViewController.swift
+++ b/Sources/TGCardViewController/TGMapViewController.swift
@@ -1,0 +1,36 @@
+//
+//  TGMapViewController.swift
+//  TGCardViewController
+//
+//  Created by Adrian Schönig on 31/8/21.
+//  Copyright © 2021 SkedGo Pty Ltd. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// A container view controller for the map view, to set its safe area separately from the main TGCardVC
+class TGMapViewController: UIViewController {
+  
+  var builder: TGCompatibleMapBuilder = TGMapKitBuilder()
+  
+  var mapView: UIView! { view }
+  
+  override func loadView() {
+    let mapView = builder.buildMapView()
+    self.view = mapView
+  }
+  
+  var isUserInteractionEnabled: Bool {
+    get { mapView.isUserInteractionEnabled }
+    set {
+      mapView.isUserInteractionEnabled = newValue
+
+      // This is a weird but functioning way of making the map not accessible
+      // in a reliable way
+      mapView.accessibilityFrame = newValue ? mapView.frame : .zero
+      UIAccessibility.post(notification: .layoutChanged, argument: nil)
+    }
+  }
+  
+}

--- a/TGCardViewController.xcodeproj/project.pbxproj
+++ b/TGCardViewController.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3A7C348A201F2C0B00F66A35 /* TGCardViewController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A7C3483201F2C0B00F66A35 /* TGCardViewController.framework */; };
 		3A7C348B201F2C0B00F66A35 /* TGCardViewController.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3A7C3483201F2C0B00F66A35 /* TGCardViewController.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3AC6891D26DDE14C00AFB1AB /* TGMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC6891C26DDE14C00AFB1AB /* TGMapViewController.swift */; };
 		3ACD924C26CCF88F0075CCF3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3ACD922426CCF88F0075CCF3 /* Localizable.strings */; };
 		3ACD924D26CCF88F0075CCF3 /* TGButtonPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACD922626CCF88F0075CCF3 /* TGButtonPosition.swift */; };
 		3ACD924E26CCF88F0075CCF3 /* UIView+Snap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACD922726CCF88F0075CCF3 /* UIView+Snap.swift */; };
@@ -101,6 +102,7 @@
 		3AA58E6320D8FEAB00FE37B0 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		3AA58E6420D8FEB400FE37B0 /* TGCardViewController.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = TGCardViewController.podspec; sourceTree = SOURCE_ROOT; };
 		3AA58E6520D8FEBA00FE37B0 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
+		3AC6891C26DDE14C00AFB1AB /* TGMapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TGMapViewController.swift; sourceTree = "<group>"; };
 		3ACA74801E716AFC00408678 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3ACD922526CCF88F0075CCF3 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3ACD922626CCF88F0075CCF3 /* TGButtonPosition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TGButtonPosition.swift; sourceTree = "<group>"; };
@@ -230,6 +232,7 @@
 				3ACD924426CCF88F0075CCF3 /* TGCompatibleMapBuilder.swift */,
 				3ACD922826CCF88F0075CCF3 /* TGCompatibleMapBuilder+MapKit.swift */,
 				3ACD924326CCF88F0075CCF3 /* TGMapManager.swift */,
+				3AC6891C26DDE14C00AFB1AB /* TGMapViewController.swift */,
 				3ACD922726CCF88F0075CCF3 /* UIView+Snap.swift */,
 				3ACD92AD26CCF9C30075CCF3 /* Supporting Files */,
 			);
@@ -510,6 +513,7 @@
 				3ACD926D26CCF88F0075CCF3 /* TGKeyboardTableView.swift in Sources */,
 				3ACD925226CCF88F0075CCF3 /* TGCard.swift in Sources */,
 				3ACD925F26CCF88F0075CCF3 /* TGPageCardView.swift in Sources */,
+				3AC6891D26DDE14C00AFB1AB /* TGMapViewController.swift in Sources */,
 				3ACD925926CCF88F0075CCF3 /* TGPlainCard.swift in Sources */,
 				3ACD925826CCF88F0075CCF3 /* TGPageCard.swift in Sources */,
 				3ACD926526CCF88F0075CCF3 /* TGGrabHandleView.swift in Sources */,


### PR DESCRIPTION
This PR restructured TGCardVC slightly to have the map view in its own VC with, critically, its own safe area. The safe area is the visible part of the map when the card VC is in collapsed or peaking mode.

This fixes the positioning of the attribution and legal label when used with MKMapView, and it fixes setting the centre location of the map or taking the map into tracking mode when the card is in peaking mode.

Additional changes:

- When the card is extended the map is made non-interactive to disable it from surfacing any VoiceOver from underneath the extended card.
- Removes the need for manually handling `edgePadding` when using the MKMapView-based TGMapManager.

Bugs to address:

- [x] The maps attribution label jumps to its new position when tapping to expand
- [x] Doesn't deal with card header properly (e.g., "Show pages" in example)
- [x] Wrong map safe area on first load
- [x] Wrong left map safe area on iPad in landscape