### PR TITLE
Fix issue where a page header accessory couldn't be tapped

### DIFF
--- a/Sources/TGCardViewController/cards/TGPageHeaderView.swift
+++ b/Sources/TGCardViewController/cards/TGPageHeaderView.swift
@@ -13,6 +13,9 @@ public class TGPageHeaderView: TGHeaderView {
   @IBOutlet weak var accessoryWrapperView: UIView!
   @IBOutlet weak var accessoryWrapperHeightConstraint: NSLayoutConstraint!
   
+  @IBOutlet weak var accessoryTrailingConstraint: NSLayoutConstraint!
+  @IBOutlet weak var buttonTrailingConstraint: NSLayoutConstraint!
+  
   static func instantiate() -> TGPageHeaderView {
     guard
       let view = TGCardViewController.bundle.loadNibNamed("TGPageHeaderView", owner: nil, options: nil)!.first as? TGPageHeaderView
@@ -68,7 +71,17 @@ public class TGPageHeaderView: TGHeaderView {
   
   var rightAction: (() -> Void)? {
     didSet {
-      rightButton?.isHidden = (rightAction == nil)
+      if rightAction != nil {
+        rightButton?.isHidden = false
+        accessoryTrailingConstraint.priority = .defaultLow
+        buttonTrailingConstraint.priority = .required
+        setNeedsUpdateConstraints()
+      } else {
+        rightButton?.isHidden = true
+        accessoryTrailingConstraint.priority = .required
+        buttonTrailingConstraint.priority = .defaultLow
+        setNeedsUpdateConstraints()
+      }
     }
   }
   

--- a/Sources/TGCardViewController/cards/TGPageHeaderView.xib
+++ b/Sources/TGCardViewController/cards/TGPageHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17132" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17105"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,14 +14,14 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" placeholderIntrinsicWidth="200" placeholderIntrinsicHeight="44" translatesAutoresizingMaskIntoConstraints="NO" id="OCh-my-Dlb">
-                    <rect key="frame" x="87.5" y="0.0" width="200" height="45"/>
+                    <rect key="frame" x="8" y="0.0" width="359" height="45"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" constant="44" id="0l9-rR-FKT"/>
                     </constraints>
                 </view>
-                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="252" verticalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pyb-jC-raq">
-                    <rect key="frame" x="321" y="0.5" width="46" height="44"/>
+                <button hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="252" verticalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pyb-jC-raq">
+                    <rect key="frame" x="375" y="0.5" width="46" height="44"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="6JN-fE-ZuQ"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="gHy-ly-PZq"/>
@@ -34,18 +34,21 @@
             </subviews>
             <constraints>
                 <constraint firstItem="Pyb-jC-raq" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="OCh-my-Dlb" secondAttribute="trailing" constant="8" id="5Qb-fu-D1X"/>
+                <constraint firstAttribute="trailing" secondItem="OCh-my-Dlb" secondAttribute="trailing" constant="8" id="QJG-5Z-I6Z"/>
                 <constraint firstItem="OCh-my-Dlb" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" priority="750" id="QQf-ys-52l"/>
                 <constraint firstItem="Pyb-jC-raq" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="TgX-Dl-BGD"/>
                 <constraint firstItem="OCh-my-Dlb" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="aN7-j2-ag0"/>
                 <constraint firstItem="OCh-my-Dlb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="bei-eH-bzY"/>
                 <constraint firstAttribute="bottom" secondItem="OCh-my-Dlb" secondAttribute="bottom" id="ra6-e8-MxP"/>
-                <constraint firstAttribute="trailing" secondItem="Pyb-jC-raq" secondAttribute="trailing" constant="8" id="yTg-vg-Ckc"/>
+                <constraint firstAttribute="trailing" secondItem="Pyb-jC-raq" secondAttribute="trailing" priority="250" constant="8" id="yTg-vg-Ckc"/>
             </constraints>
             <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
+                <outlet property="accessoryTrailingConstraint" destination="QJG-5Z-I6Z" id="hbD-rl-CNm"/>
                 <outlet property="accessoryWrapperHeightConstraint" destination="0l9-rR-FKT" id="Y6r-2G-EG1"/>
                 <outlet property="accessoryWrapperView" destination="OCh-my-Dlb" id="3ch-WX-uOk"/>
+                <outlet property="buttonTrailingConstraint" destination="yTg-vg-Ckc" id="rWM-hV-Zcz"/>
                 <outlet property="rightButton" destination="Pyb-jC-raq" id="GH0-fI-qaE"/>
             </connections>
             <point key="canvasLocation" x="92" y="-4.0479760119940034"/>


### PR DESCRIPTION
... on the trailing side, if no `rightAction` was set